### PR TITLE
Exposing cql2elm as an npm bin command.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,9 +2,6 @@
 /yarn-error.log
 /dist
 /test
-/gradle
-/gradlew*
-/build.gradle
 src/doc-gen.js
 **/.vscode
 **/.vscache

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Your CQL _and ELM JSON_ files should reside somewhere in your project. The easie
 
 If your CQL logic uses any other CQL libraries, those must be provided as well. Again, it is easiest to put them in the same `cql` folder along side your own CQL, but this is not strictly necessary.
 
-Each CQL file must have its corresponding ELM JSON file. The CQL Testing Framework currently does not support any method for translating CQL to ELM JSON. If you use the [CDS Authoring Tool](https://cds.ahrq.gov/authoring/), the downloaded zip package will already contain ELM JSON.  If you only have the CQL source, you must translate it to ELM JSON using something like the [CQL-to-ELM translator](https://github.com/cqframework/clinical_quality_language/blob/master/Src/java/cql-to-elm/OVERVIEW.md).
+Each CQL file must have its corresponding ELM JSON file before tests can be run. If you use the [CDS Authoring Tool](https://cds.ahrq.gov/authoring/), the downloaded zip package will already contain ELM JSON and so no further steps are needed in this case.  If you only have the CQL source, you must translate it to ELM JSON using something like the [CQL-to-ELM translator](https://github.com/cqframework/clinical_quality_language/blob/master/Src/java/cql-to-elm/OVERVIEW.md). The CQL Testing Framework includes a copy of this translator which is exposed as an npm executable command; for more information [see below]()
 
 #### ./node_modules
 
@@ -227,6 +227,14 @@ $ npm install
 ```
 
 This only needs to be done once.  After this, your `node_modules` folder will be populated and all test runs will reference it for the necessary dependencies.
+
+#### Translating CQL TO ELM
+
+This step is only necessary if the ELM JSON representation is not already available (e.g., it was produced by the CDS Authoring Tool). The CQL Testing Framework includes scripts for running the [CQL-to-ELM translator](https://github.com/cqframework/clinical_quality_language/blob/master/Src/java/cql-to-elm/OVERVIEW.md), however a requirement for using this functionality is that Java SE Development Kit 11 is installed on the system. [The following page](https://github.com/cqframework/clinical_quality_language/blob/master/Src/java/README.md) contains more information on installing Java. Once Java is installed, CQL can be translated to ELM by running the following command from the root directory of your project:
+
+```
+npx cql-to-elm /path/to/folder/with/cql
+```
 
 #### Downloading Value Sets
 

--- a/bin/cql2elm.js
+++ b/bin/cql2elm.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+const { platform, argv, cwd } = require('process');
+const { join, resolve, sep } = require('path');
+const { exec } = require('child_process');
+
+let exeCmd = platform == 'win32' ? 'gradlew.bat' : './gradlew';
+
+let inputArgs = argv;
+
+let targetDir;
+if (inputArgs.length > 2) {
+  targetDir = cwd() + sep + inputArgs[2];
+} else {
+  targetDir = cwd();
+}
+
+exec(
+  exeCmd + ' cql2elm --project-prop targetDir=' + targetDir, 
+  {
+    cwd: resolve(join(__dirname, '..'))
+  }, 
+  (error, stdout, stderr) => {
+    if (error) {
+      console.error(error);
+      return;
+    }
+    // eslint-disable-next-line no-console
+    console.log(stdout);
+    console.error(stderr);
+  }
+);

--- a/build.gradle
+++ b/build.gradle
@@ -13,5 +13,9 @@ dependencies {
 task cql2elm(type: JavaExec) {
   classpath = sourceSets.main.runtimeClasspath
   main = 'org.cqframework.cql.cql2elm.CqlTranslator'
-  args '--input', './test/yaml', '--format', 'JSON'
+  if (project.hasProperty("targetDir")) {
+    args '--input', targetDir, '--format', 'JSON'  
+  } else { // NOTE: For translating CQL for `cql-testing` built-in tests.
+    args '--input', './test/yaml', '--format', 'JSON'
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cql-testing",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Provides utilities for testing CQL logic",
   "license": "Apache-2.0",
   "main": "src/index.js",
@@ -34,5 +34,8 @@
   },
   "resolutions": {
     "lodash": "^4.17.21"
+  },
+  "bin": {
+    "cql-to-elm": "bin/cql2elm.js"
   }
 }


### PR DESCRIPTION
Porting over original merge request from https://gitlab.mitre.org/cervical-cancer-cds/cql-testing/-/merge_requests/1. This pull request exposes `cql-to-elm` as an npm bin command so that CQL to ELM JSON conversion is supported from within CQL Testing Framework.

Can verify bin command working using the packaged version of this branch in [Cervical Cancer Screening and Management (CCSM) Clinical Decision Support (CDS) with Tests](https://github.com/ccsm-cds-tools/ccsm-cds-with-tests) project.
