### PR TITLE
Type Quantity

### DIFF
--- a/src/buildTestSuite.js
+++ b/src/buildTestSuite.js
@@ -147,7 +147,6 @@ function checkResult(expr, actual, expected) {
   } else {
     const simpleResult = simplifyResult(actual);
     const message = `${expr}=<${simpleResult}>`;
-    console.log(simpleResult,expected);
     expect(simpleResult, message).to.eql(expected);
   }
 }

--- a/src/buildTestSuite.js
+++ b/src/buildTestSuite.js
@@ -158,6 +158,12 @@ function simplifyResult(result) {
     return result.map(r => simplifyResult(r));
   } else if (result instanceof cql.DateTime || result.constructor.name === 'DateTime') {
     return result.toString();
+  } else if (result instanceof cql.Quantity || result.constructor.name === 'Quantity') {
+    let result2 = {};
+    for (const key of Object.keys(result)) {
+      result2[key] = simplifyResult(result[key]);
+    }
+    return result2;
   } else if (result != null && typeof result === 'object') {
     for (const key of Object.keys(result)) {
       result[key] = simplifyResult(result[key]);

--- a/src/buildTestSuite.js
+++ b/src/buildTestSuite.js
@@ -147,6 +147,7 @@ function checkResult(expr, actual, expected) {
   } else {
     const simpleResult = simplifyResult(actual);
     const message = `${expr}=<${simpleResult}>`;
+    console.log(simpleResult,expected);
     expect(simpleResult, message).to.eql(expected);
   }
 }
@@ -157,6 +158,8 @@ function simplifyResult(result) {
   } else if (Array.isArray(result)) {
     return result.map(r => simplifyResult(r));
   } else if (result instanceof cql.DateTime || result.constructor.name === 'DateTime') {
+    return result.toString();
+  } else if (result instanceof cql.Date || result.constructor.name === 'Date') {
     return result.toString();
   } else if (result instanceof cql.Quantity || result.constructor.name === 'Quantity') {
     let result2 = {};


### PR DESCRIPTION
Adding another special case to the simplify result logic for values of type Quantity.

The reason for the need is likely due to the Execution Engine moving
to TypeScript: https://github.com/cqframework/cql-execution/commit/4e1c56a05e4b3ae06983fbb5eb7b32ab6a2287d6

Previously, the Execution Engine would output values of type Quantity
as plain objects, but now they have a class of Quantity.

Because we cannot specify classes as part of our expected results,
we need this special case now when using the execution engine > v2.4.