### PR TITLE
Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ repositories {
 
 dependencies {
   runtimeOnly 'info.cqframework:cql-to-elm-cli:3.2.0'
+  runtimeOnly 'xmlpull:xmlpull:1.1.3.1'
 }
 
 task cql2elm(type: JavaExec) {


### PR DESCRIPTION
Added xmlpull dependency

At least when I added cql-testing to my my package.json at work, I had to hack the `node_modules/cql-testing/build.gradle` file as I have done in this PR.